### PR TITLE
ci: add OpenAPI type check job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,37 @@ env:
   CI: true
 
 jobs:
+  openapi-check:
+    name: OpenAPI Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - run: pnpm prisma generate
+        working-directory: apps/cms-api
+
+      - run: pnpm type-check
+        working-directory: apps/cms-api
+
+      - run: pnpm build:openapi
+
+      - name: check if cms-admin files are changed
+        run: git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep "apps/cms-admin" && exit 1 || exit 0
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: openapi-check
 
     steps:
       - uses: actions/checkout@v4

--- a/.idea/runConfigurations/build_openapi.xml
+++ b/.idea/runConfigurations/build_openapi.xml
@@ -3,7 +3,7 @@
     <package-json value="$PROJECT_DIR$/apps/cms-admin/package.json" />
     <command value="run" />
     <scripts>
-      <script value="swagger" />
+      <script value="build:openapi" />
     </scripts>
     <node-interpreter value="project" />
     <envs />

--- a/apps/cms-admin/package.json
+++ b/apps/cms-admin/package.json
@@ -8,12 +8,12 @@
     "version": "pnpm changelog && git add CHANGELOG.md",
     "dev": "vite",
     "build": "vite build",
+    "build:openapi": "tsx scripts/sync-swagger-api.js && eslint --fix src/client/cms/cms-api.ts",
     "serve": "vite preview",
     "type-check": "tsc",
     "lint": "eslint .",
     "test": "pnpm test:unit",
     "test:unit": "vitest run",
-    "swagger": "tsx scripts/sync-swagger-api.js && eslint --fix src/client/cms/cms-api.ts",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
   "dependencies": {

--- a/apps/cms-page-builder/package.json
+++ b/apps/cms-page-builder/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@testing-library/cypress": "^10.0.2",
     "@vitejs/plugin-vue": "^5.1.3",
-    "concurrently": "^8.2.2",
     "cypress": "^13.14.1",
     "cypress-multi-reporters": "^1.6.4",
     "eslint-plugin-cypress": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "main": "index.js",
   "scripts": {
     "prepare": "simple-git-hooks",
+    "cms-api": "pnpm --filter cms-api",
+    "cms-admin": "pnpm --filter cms-admin",
     "build": "pnpm -r build",
+    "build:openapi": "concurrently -rk -s first \"pnpm cms-api exec nest start\" \"wait-on http://localhost:10300/docs-json && pnpm cms-admin build:openapi\"  2> /dev/null",
+    "build:prisma": "pnpm cms-api exec prisma generate",
     "type-check": "pnpm -r type-check",
     "test": "vitest run"
   },
@@ -24,13 +28,15 @@
     "@types/node": "^20",
     "@vitest/coverage-v8": "^2.0.5",
     "@vitest/ui": "^2.0.5",
+    "concurrently": "^8.2.2",
     "eslint": "^9.9.1",
     "lint-staged": "^15.2.9",
     "simple-git-hooks": "^2.11.1",
     "tsx": "^4.19.0",
     "type-fest": "^4.26.0",
     "typescript": "~5.5.4",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "wait-on": "^8.0.0"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@vitest/ui':
         specifier: ^2.0.5
         version: 2.0.5(vitest@2.0.5)
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
       eslint:
         specifier: ^9.9.1
         version: 9.9.1
@@ -48,6 +51,9 @@ importers:
       vitest:
         specifier: ^2.0.5
         version: 2.0.5(@types/node@20.16.3)(@vitest/ui@2.0.5)(happy-dom@15.7.3)(sass@1.77.8)(terser@5.31.6)
+      wait-on:
+        specifier: ^8.0.0
+        version: 8.0.0
 
   apps/cms-admin:
     dependencies:
@@ -237,9 +243,6 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.1.3
         version: 5.1.3(vite@5.4.2(@types/node@20.16.3)(sass@1.77.8)(terser@5.31.6))(vue@3.4.38(typescript@5.5.4))
-      concurrently:
-        specifier: ^8.2.2
-        version: 8.2.2
       cypress:
         specifier: ^13.14.1
         version: 13.14.1
@@ -691,6 +694,12 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
+  '@hapi/hoek@9.3.0':
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+
+  '@hapi/topo@5.1.0':
+    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
@@ -1061,6 +1070,15 @@ packages:
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  '@sideway/address@4.1.5':
+    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
+
+  '@sideway/formula@3.0.1':
+    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
+
+  '@sideway/pinpoint@2.0.0':
+    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -3268,6 +3286,9 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
+  joi@17.13.3:
+    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
   jquery@3.7.1:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
 
@@ -5108,6 +5129,11 @@ packages:
       typescript:
         optional: true
 
+  wait-on@8.0.0:
+    resolution: {integrity: sha512-fNE5SXinLr2Bt7cJvjvLg2PcXfqznlqRvtE3f8AqYdRZ9BhE+XpsCp1mwQbRoO7s1q7uhAuCw0Ro3mG/KdZjEw==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
@@ -5601,6 +5627,12 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
+  '@hapi/hoek@9.3.0': {}
+
+  '@hapi/topo@5.1.0':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.3.0': {}
@@ -5957,6 +5989,14 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@sideway/address@4.1.5':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@sideway/formula@3.0.1': {}
+
+  '@sideway/pinpoint@2.0.0': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -8516,6 +8556,14 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  joi@17.13.3:
+    dependencies:
+      '@hapi/hoek': 9.3.0
+      '@hapi/topo': 5.1.0
+      '@sideway/address': 4.1.5
+      '@sideway/formula': 3.0.1
+      '@sideway/pinpoint': 2.0.0
+
   jquery@3.7.1: {}
 
   js-tokens@4.0.0: {}
@@ -10484,6 +10532,16 @@ snapshots:
       '@vue/shared': 3.4.38
     optionalDependencies:
       typescript: 5.5.4
+
+  wait-on@8.0.0:
+    dependencies:
+      axios: 1.7.7
+      joi: 17.13.3
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
 
   warning@4.0.3:
     dependencies:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a new CI job for OpenAPI type checking to ensure type safety and correctness in API specifications. Update the build workflow to depend on the successful completion of this new job, ensuring that type checks are performed before the build process.

Build:
- Update the build job in the CI workflow to depend on the successful completion of the new OpenAPI type check job.

CI:
- Add a new CI job for OpenAPI type checking, which includes steps for setting up the environment, installing dependencies, generating Prisma client, running type checks, and building OpenAPI specifications.

<!-- Generated by sourcery-ai[bot]: end summary -->